### PR TITLE
Add frontend API services

### DIFF
--- a/frontend/src/app/empresas/page.tsx
+++ b/frontend/src/app/empresas/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -17,110 +17,30 @@ import {
   Globe
 } from "lucide-react";
 import Link from "next/link";
+import { getCompanies } from "@/lib/services/companies";
 
 export default function EmpresasPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
+  const [companies, setCompanies] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-  // Mock data - in real app, this would come from API
-  const companies = [
-    {
-      id: "1",
-      name: "SolarTech Brasil",
-      description: "Especializada em sistemas fotovoltaicos residenciais e comerciais com mais de 15 anos de experiência no mercado brasileiro.",
-      rating: 4.8,
-      reviewCount: 234,
-      city: "São Paulo",
-      state: "SP",
-      projectCount: 450,
-      verified: true,
-      logo: "ST",
-      services: ["Residencial", "Comercial", "Industrial"],
-      phone: "(11) 99999-9999",
-      email: "contato@solartech.com.br",
-      website: "www.solartech.com.br"
-    },
-    {
-      id: "2",
-      name: "Energia Verde Ltda",
-      description: "Empresa focada em soluções sustentáveis de energia solar para residências e pequenos comércios.",
-      rating: 4.6,
-      reviewCount: 189,
-      city: "Rio de Janeiro",
-      state: "RJ",
-      projectCount: 320,
-      verified: true,
-      logo: "EV",
-      services: ["Residencial", "Comercial"],
-      phone: "(21) 88888-8888",
-      email: "info@energiaverde.com.br",
-      website: "www.energiaverde.com.br"
-    },
-    {
-      id: "3",
-      name: "Sol & Cia",
-      description: "Instalação e manutenção de sistemas solares com garantia estendida e suporte técnico 24/7.",
-      rating: 4.9,
-      reviewCount: 156,
-      city: "Belo Horizonte",
-      state: "MG",
-      projectCount: 280,
-      verified: true,
-      logo: "SC",
-      services: ["Residencial", "Manutenção"],
-      phone: "(31) 77777-7777",
-      email: "contato@solecia.com.br",
-      website: "www.solecia.com.br"
-    },
-    {
-      id: "4",
-      name: "PowerSun Energia",
-      description: "Líder em projetos de grande porte, atendendo indústrias e complexos comerciais em todo o país.",
-      rating: 4.7,
-      reviewCount: 298,
-      city: "Porto Alegre",
-      state: "RS",
-      projectCount: 520,
-      verified: true,
-      logo: "PS",
-      services: ["Industrial", "Comercial", "Residencial"],
-      phone: "(51) 66666-6666",
-      email: "vendas@powersun.com.br",
-      website: "www.powersun.com.br"
-    },
-    {
-      id: "5",
-      name: "EcoSolar Nordeste",
-      description: "Especializada no mercado nordestino, aproveitando o alto índice de irradiação solar da região.",
-      rating: 4.5,
-      reviewCount: 167,
-      city: "Fortaleza",
-      state: "CE",
-      projectCount: 380,
-      verified: true,
-      logo: "EN",
-      services: ["Residencial", "Comercial", "Rural"],
-      phone: "(85) 55555-5555",
-      email: "contato@ecosolar.com.br",
-      website: "www.ecosolar.com.br"
-    },
-    {
-      id: "6",
-      name: "Solar Inovação",
-      description: "Empresa jovem e inovadora, focada em tecnologias de ponta e soluções personalizadas.",
-      rating: 4.4,
-      reviewCount: 89,
-      city: "Brasília",
-      state: "DF",
-      projectCount: 150,
-      verified: false,
-      logo: "SI",
-      services: ["Residencial", "Comercial"],
-      phone: "(61) 44444-4444",
-      email: "info@solarinovacao.com.br",
-      website: "www.solarinovacao.com.br"
-    }
-  ];
+  useEffect(() => {
+    const fetchCompanies = async () => {
+      setLoading(true);
+      try {
+        const response = await getCompanies();
+        setCompanies(response.data || response);
+      } catch (err) {
+        console.error(err);
+        setError("Erro ao carregar empresas");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCompanies();
+  }, []);
 
   const filteredCompanies = companies.filter(company =>
     company.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -217,9 +137,14 @@ export default function EmpresasPage() {
 
         {/* Results Count */}
         <div className="mb-6">
-          <p className="text-gray-600">
-            Mostrando {filteredCompanies.length} de {companies.length} empresas
-          </p>
+          {loading ? (
+            <p className="text-gray-600">Carregando empresas...</p>
+          ) : (
+            <p className="text-gray-600">
+              Mostrando {filteredCompanies.length} de {companies.length} empresas
+            </p>
+          )}
+          {error && <p className="text-red-600 text-sm">{error}</p>}
         </div>
 
         {/* Companies Grid */}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { LogIn, Eye, EyeOff, Mail, Lock } from "lucide-react";
 import Link from "next/link";
+import { login as loginRequest } from "@/lib/services/auth";
 
 export default function LoginPage() {
   const [formData, setFormData] = useState({
@@ -30,23 +31,12 @@ export default function LoginPage() {
     setError("");
 
     try {
-      // In real app, make API call here
-      console.log("Login attempt:", formData);
-      
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Simulate successful login
-      localStorage.setItem('user', JSON.stringify({
-        id: '1',
-        email: formData.email,
-        name: 'Usuário Teste',
-        role: 'consumer'
-      }));
-      
-      // Redirect to dashboard or home
-      window.location.href = '/';
-      
+      const data = await loginRequest(formData);
+      localStorage.setItem("token", data.access_token);
+      if (data.user) {
+        localStorage.setItem("user", JSON.stringify(data.user));
+      }
+      window.location.href = "/";
     } catch (error) {
       console.error("Login error:", error);
       setError("Credenciais inválidas. Tente novamente.");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api'
+});
+
+export default api;

--- a/frontend/src/lib/services/auth.ts
+++ b/frontend/src/lib/services/auth.ts
@@ -1,0 +1,31 @@
+import api from '../api';
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload {
+  email: string;
+  password: string;
+  name: string;
+}
+
+export async function login(payload: LoginPayload) {
+  const { data } = await api.post('/auth/login', payload);
+  return data;
+}
+
+export async function register(payload: RegisterPayload) {
+  const { data } = await api.post('/auth/register', payload);
+  return data;
+}
+
+export async function getProfile(token: string) {
+  const { data } = await api.get('/auth/profile', {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+  return data;
+}

--- a/frontend/src/lib/services/companies.ts
+++ b/frontend/src/lib/services/companies.ts
@@ -1,0 +1,31 @@
+import api from '../api';
+
+export interface CompanyFilters {
+  page?: number;
+  limit?: number;
+  city?: string;
+  state?: string;
+  services?: string;
+  minRating?: number;
+  q?: string;
+}
+
+export async function getCompanies(filters: CompanyFilters = {}) {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      params.append(key, String(value));
+    }
+  });
+  const { data } = await api.get(`/companies?${params.toString()}`);
+  return data;
+}
+
+export async function getCompany(id: string) {
+  const { data } = await api.get(`/companies/${id}`);
+  return data;
+}
+
+export async function searchCompanies(query: string, filters: CompanyFilters = {}) {
+  return getCompanies({ ...filters, q: query });
+}

--- a/frontend/src/lib/services/quotes.ts
+++ b/frontend/src/lib/services/quotes.ts
@@ -1,0 +1,26 @@
+import api from '../api';
+
+export interface QuotePayload {
+  companyId: string;
+  name: string;
+  email: string;
+  phone: string;
+  message?: string;
+  projectType?: string;
+  estimatedPower?: string;
+  location?: string;
+}
+
+export async function createQuote(payload: QuotePayload) {
+  const { data } = await api.post('/quotes', payload);
+  return data;
+}
+
+export async function getQuotes(token: string) {
+  const { data } = await api.get('/quotes', {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+  return data;
+}

--- a/frontend/src/lib/services/reviews.ts
+++ b/frontend/src/lib/services/reviews.ts
@@ -1,0 +1,36 @@
+import api from '../api';
+
+export interface ReviewFilters {
+  page?: number;
+  limit?: number;
+  companyId?: string;
+  userId?: string;
+  minRating?: number;
+}
+
+export interface ReviewPayload {
+  companyId: string;
+  rating: number;
+  title?: string;
+  content?: string;
+}
+
+export async function getReviews(filters: ReviewFilters = {}) {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      params.append(key, String(value));
+    }
+  });
+  const { data } = await api.get(`/reviews?${params.toString()}`);
+  return data;
+}
+
+export async function createReview(payload: ReviewPayload, token: string) {
+  const { data } = await api.post('/reviews', payload, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary
- add axios API helper and service wrappers for auth/companies/reviews/quotes
- integrate EmpresasPage with company service
- use auth service for login page

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react-map-gl', parameter implicitly has an 'any' type)*
- `npm test` in backend *(fails: Prisma types missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d3774b5a48326ba7381f5e2fd4ea0